### PR TITLE
Add writeMultiple()

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Output: The item in the stored type with name `name` in file `filePath`<br>
 Required inputs: `filePath`<br>
 Output: A list of all datas in their respective types<br>
 
+#### write() ####
+Required inputs: `filePath`, `name`, `type`, `value`<br>
+Optional inputs: `mode` (default "a")<br>
+Write a value to a pyson file
+
 #### updateData() ####
 Required inputs: `filePath`, `name`, `data`<br>
 Updates entry `name` to contain value `data`<br>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Required inputs: `filePath`, `name`, `type`, `value`<br>
 Optional inputs: `mode` (default "a")<br>
 Write a value to a pyson file
 
+#### writeMultiple() ####
+Required inputs: `filePath`, `data`<br>
+Optional inputs: `mode` (default "a")<br>
+Write a dict of name to value to a pyson file (automatically figures out the type)
+
 #### updateData() ####
 Required inputs: `filePath`, `name`, `data`<br>
 Updates entry `name` to contain value `data`<br>
@@ -33,7 +38,7 @@ Output: Whether or not function call worked<br>
 #### isCompatible() ####
 Required inputs: `filePath`<br>
 Outputs: Bool<br>
-Checks if a file is compatible with .pyson file format. Returns True if so, returns False if not. <br>
+Checks if a file is compatible with .pyson file format. Returns True if so, returns False if not.<br>
 
 ## Supported Types ##
 There are 4 supported types: int, float, str, and list

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PYSON #
-##### Maintained by: [OmegaGodzilla66](https://github.com/OmegaGodzilla66), [ComputingSquid](https://github.com/ProbablyComputingSquid), and [coolSchnoodle](https://github.com/coolSchnoodle) #####
+##### Maintained by: [OmegaGodzilla66](https://github.com/OmegaGodzilla66), [ComputingSquid](https://github.com/ProbablyComputingSquid), and [CoolSchnoodle](https://github.com/coolSchnoodle) #####
 
 
 ## Overview ##
@@ -7,13 +7,14 @@ The purpose of this project is to provide a python-based alternative to JSON. Th
 
 ## How to Use ##
 **THIS PROJECT IS NOT YET FINISHED! DOCUMENTATION IS ONLY SHOWN FOR COMPLETED FEATURES. SOME FEATURES MAY BREAK DUE TO CONTINUED DEVELOPMENT. IF YOU SEE A PROBLEM, PLEASE LET ME KNOW!**
-<br>Believe it or not, this project is surprisingly easy to use.<br><br> The only thing you have to do is `pip install pyson-data` ! From then, you can just `import pyson_data as pyson` <ul>**NOTE: due to some goofups by computingsquid late at night, turns out you can't use `-` in a package name, so when you pip install, use `-` but when you import, use `_`**</ul>, and use functions as normal! Support for other languages may come soon.<br>
-**The PYSON format does NOT include a newline at the end of the file, files with a newline at the end will be considered invalid**
+<br>Believe it or not, this project is surprisingly easy to use.<br>
+<br> The only thing you have to do is `pip install pyson-data` ! From then, you can just `import pyson_data as pyson`, and use functions as normal!
+Support for other languages may come soon.<br>
 ### List of Functions ###
 
 #### getData() ####
-Required inputs: `filePath`, `datacall`<br>
-Output: The item in the stored type at index `datacall` in file `filePath`<br>
+Required inputs: `filePath`, `name`<br>
+Output: The item in the stored type with name `name` in file `filePath`<br>
 
 #### getWhole() ####
 Required inputs: `filePath`<br>
@@ -27,14 +28,15 @@ Output: Whether or not function call worked<br>
 #### isCompatible() ####
 Required inputs: `filePath`<br>
 Outputs: Bool<br>
-Checks if a file is compatible with .cnf file format. Returns True if so, returns False if not. <br>
+Checks if a file is compatible with .pyson file format. Returns True if so, returns False if not. <br>
 
 ## Supported Types ##
 There are 4 supported types: int, float, str, and list
 <br><br>
 - An int is a whole number that can be any value<br>
 - A str is a list of text (quotes not required)<br>
-- A list is a list of values, which currently have to all be strings. List items are seperated by the (*) seperator. Currently there is no escaping support. I don't really know why you would use that value normally in a list. <br> 
+- A list is a list of values, which currently have to all be strings. List items are seperated by the (*) seperator.
+Currently there is no escaping support. I don't really know why you would use that value normally in a list. <br> 
 - A float is a decimal number, that can be any value<br>
 
 More supported types may be added. 
@@ -47,13 +49,13 @@ More supported types may be added.
 - v0.0.6: Added floats
 - v0.0.5: Updated naming system, ported to github!
 - v0.0.4: Added a function that checks if a file is compatible with .pyson file format. Fixed a bug in the write. Other general bug fixes. 
-- v0.0.3: Added a write function! This is now (technicaally) a fully functioning data service!
+- v0.0.3: Added a write function! This is now (technically) a fully functioning data service!
 - v0.0.2: Added a read function for the whole file. Returns a list of all contents. This is actually getting pretty cool!
-- v0.0.1: Initial launch! Basic reading features for a .cnf file. Current compatible types are string, int, and list.
+- v0.0.1: Initial launch! Basic reading features for a .cnf (renamed almost immediately to pyson) file. Current compatible types are string, int, and list.
 
 ### Dev comments ###
 0.0.8:<br>
-> I (computingSquid) have had to resort to drastic measures to get my pull request approved. coolSchnoodle was forced to say "uwu"
+> I (computingSquid) have had to resort to drastic measures to get my pull request approved. CoolSchnoodle was forced to say "uwu"
 
 0.0.5: <br>
 > Wahoo! Porting to github!...oh shoot now I have to rename everything.

--- a/src/pyson_data/pyson.py
+++ b/src/pyson_data/pyson.py
@@ -137,6 +137,22 @@ def write(filePath: str, name: str, type: str, value: PysonValue, mode: str = "a
         toWrite = "\n" + toWrite
     open(filePath, mode).write(toWrite)
 
+def writeMultiple(filePath: str, data: dict[str, PysonValue], mode: str = "a") -> None:
+    for tup in data.items():
+        name, value = tup
+        type = ""
+        if isinstance(value, list):
+            type = "list"
+        if isinstance(value, int):
+            type = "int"
+        if isinstance(value, float):
+            type = "float"
+        if isinstance(value, str):
+            type = "str"
+        if type == "":
+            raise Exception("Invalid pyson typein writeMultiple()")
+        write(filePath, name, type, value, mode)
+        mode = "a"
 
 def updateData(filePath: str, name: str, data: str) -> None:
     """

--- a/tests/example.py
+++ b/tests/example.py
@@ -1,4 +1,5 @@
-import pyson # to use this in your project, simply change the name from "pyson" to the name of the file you're importing it from
+raise Exception("This is in a different directory as pyson.py for some reason so it can't be imported normally")
+# to use this in your project, simply change the name from "pyson" to the name of the file you're importing it from
 import os
 
 # Read test


### PR DESCRIPTION
Added the writeMultiple() function which writes a dict of str to PysonValue to a pyson file.

Also a few other changes:
- write() was added to README.md
- example.py was updated to raise an exception that is more clear than just saying that it couldn't find pyson to import (I don't think there is an elegant way to fix this unfortunately)
- Fixed small issues in README.md (spelling issues, incorrect username, etc)