### PR TITLE
Remove hello() from __init__.py, fix up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,25 @@
 The purpose of this project is to provide a python-based alternative to JSON. This is a (almost) fully functional JSON-inspired data management system!
 
 ## How to Use ##
-**THIS PROJECT IS NOT YET FINISHED! DOCUMENTATION IS ONLY SHOWN FOR COMPLETED FEATURES. SOME FEATURES MAY BREAK DUE TO CONTINUED DEVELOPMENT. IF YOU SEE A PROBLEM, PLEASE LET ME KNOW!**
-<br>Believe it or not, this project is surprisingly easy to use.<br>
-<br> The only thing you have to do is `pip install pyson-data` ! From then, you can just `import pyson_data as pyson`, and use functions as normal!
+This is a pip package, so to use this in python you can just `pip install pyson-data`.
+From there, you can just `import pyson_data as pyson`.
 Support for other languages may come soon.<br>
 
-## quickstart ## 
+## Quickstart ##
 Refer to the project wiki [here](https://github.com/OmegaGodzilla66/PYSON/wiki)
 
-## documentation ##
+## Documentation ##
 Documentation has also been moved to the project wiki [here](https://github.com/OmegaGodzilla66/PYSON/wiki) to decrease clutter in the README.
 
 ## Supported Types ##
 There are 4 supported types: int, float, str, and list
 <br><br>
-- An int is a whole number that can be any value<br>
-- A str is a list of text (quotes not required)<br>
+- An int is a whole number that can be any valu
+- A str is a list of text (quotes not required)
 - A list is a list of values, which currently have to all be strings. List items are seperated by the (*) seperator.
-Currently there is no escaping support. I don't really know why you would use that value normally in a list. <br> 
-- A float is a decimal number, that can be any value<br>
-
-More supported types may be added. 
+Currently there is no escaping support. I don't really know why you would use that value normally in a list.
+- A float is a decimal number, that can be any value representable by a 64-bit floating point number.
+<br>More supported types may be added  at some point in the future. 
 
 ## Changelog ##
 - v0.1.3: Added getDict function

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PYSON #
-##### Maintained by: [OmegaGodzilla66](https://github.com/OmegaGodzilla66), [ComputingSquid](https://github.com/ProbablyComputingSquid), [CoolSchnoodle](https://github.com/coolSchnoodle), and [nmd102](https://github.com/nmd102) #####
+##### Maintained by: [OmegaGodzilla66](https://github.com/OmegaGodzilla66), [ComputingSquid](https://github.com/ProbablyComputingSquid), [CoolSchnoodle](https://github.com/CoolSchnoodle), and [nmd102](https://github.com/nmd102) #####
 
 
 ## Overview ##
@@ -36,24 +36,7 @@ Currently there is no escaping support. I don't really know why you would use th
 - v0.0.7: Fixed errors, refactored bad code
 - v0.0.6: Added floats
 - v0.0.5: Updated naming system, ported to github!
-- v0.0.4: Added a function that checks if a file is compatible with .pyson file format. Fixed a bug in the write. Other general bug fixes. 
-- v0.0.3: Added a write function! This is now (technically) a fully functioning data service!
-- v0.0.2: Added a read function for the whole file. Returns a list of all contents. This is actually getting pretty cool!
+- v0.0.4: Added a function that checks if a file is compatible with .pyson file format. Fixed a bug in the write. Other general bug fixes.
+- v0.0.3: Added a write function! This is now (technically) fully functional!
+- v0.0.2: Added a read function for the whole file. Returns a list of all contents.
 - v0.0.1: Initial launch! Basic reading features for a .cnf (renamed almost immediately to pyson) file. Current compatible types are string, int, and list.
-
-### Dev comments ###
-0.0.8:<br>
-> I (computingSquid) have had to resort to drastic measures to get my pull request approved. CoolSchnoodle was forced to say "uwu"
-
-0.0.5: <br>
-> Wahoo! Porting to github!...oh shoot now I have to rename everything.
-
-- OmegoGodzilla66
-
-0.0.4: <br>
-> HAHA I HAVE DONE IT! ... Wait no never mind I'm stupid
-
-- OmegaGodzilla66
-> Compatability checks are my nightmare. AAAAAA.
-
-- OmegaGodzilla66

--- a/src/pyson_data/__init__.py
+++ b/src/pyson_data/__init__.py
@@ -1,6 +1,2 @@
-#from .pyson import getData, getList, write, writeMultiple, updateData, checkCompatible, getDict
+# Becuase the entire source code of pyson_data is in pyson.py, this is all we need
 from .pyson import *
-# are you happy now, Eli?
-def hello():
-    print("hello world")
-    print("I love testing in production")


### PR DESCRIPTION
- Remove `hello()` from __init__.py (why was it there?)
- Make README capitalization more consistent / accurate
- Make the README more understandable
- Remove dev comments (they really didn't help)